### PR TITLE
Add Models to JWTRoutes class & init_app method #119

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,4 @@
 ### Changed
 
 -   Replaced the the `entity_type` kwarg to `table_name` in the public method `register_entity` [Issue #111](https://github.com/joegasewicz/Flask-JWT-Router/issues/111)
+-   Add Models to JWTRoutes class & init_app method [Issue #119](https://github.com/joegasewicz/Flask-JWT-Router/issues/119)

--- a/Pipfile
+++ b/Pipfile
@@ -8,6 +8,7 @@ pytest = "*"
 twine = "*"
 pyjwt = "*"
 Flask-SQLAlchemy = "*"
+Sphinx = "*"
 
 [packages]
 flask = "*"

--- a/README.md
+++ b/README.md
@@ -81,11 +81,12 @@ class UserModel(db.Model):
 # You can define the primary key name with `ENTITY_KEY` on Flask's config
 app.config["ENTITY_KEY"] = "user_id"
 # (`id` is used by default)
-JwtRoutes(app)
+JwtRoutes(app, entity_models=[UserModel, TeacherModel, ...etc])
 
-# You can also specify a list of entity model classes
-
-app.config["ENTITY_MODELS"] = [ UserModel, TeacherModel, ...etc ]
+# Or pass later with `init_app`
+def create_app(config):
+    ...
+    jwt_routes.init_app(app, entity_models=[UserModel, TeacherModel, ...etc])
 
 ```
 
@@ -181,7 +182,9 @@ An Example configuration for registering & logging in users of different types:
         ("POST", "/auth/user"), ("POST", "/auth/user/login"),
         ("POST", "/auth/teacher"), ("POST", "/auth/teacher/login"),
     ]
-    app.config["ENTITY_MODELS"] = [UserModel, TeacherModel]
+    
+    # Optionally, you can pass your models to Flask's config:
+    app.config["ENTITY_MODELS"] = [ UserModel, TeacherModel, ...etc ]
 ```
 ## Authors
 

--- a/README.md
+++ b/README.md
@@ -78,8 +78,10 @@ def register():
 class UserModel(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String)
+    
 # You can define the primary key name with `ENTITY_KEY` on Flask's config
 app.config["ENTITY_KEY"] = "user_id"
+
 # (`id` is used by default)
 JwtRoutes(app, entity_models=[UserModel, TeacherModel, ...etc])
 

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Then run:
     tox
 ```
 
-To update docs run:
+To check the docs look good locally you can run:
 ```bash
     make html
 ```

--- a/flask_jwt_router/_authentication.py
+++ b/flask_jwt_router/_authentication.py
@@ -38,6 +38,7 @@ class BaseAuthStrategy(ABC):
         # pylint:disable=missing-function-docstring
         pass
 
+    @abstractmethod
     def encode_token(self, extensions: Config, entity_id: Any, exp: int, table_name: str):
         # pylint:disable=missing-function-docstring
         pass

--- a/flask_jwt_router/_extensions.py
+++ b/flask_jwt_router/_extensions.py
@@ -1,7 +1,7 @@
 """
      The main configuration class for Flask-JWT-Router
 """
-from abc import ABC
+from abc import ABC, abstractmethod
 from typing import Dict, Any, List
 
 from ._entity import _ORMType
@@ -35,6 +35,7 @@ class Config:
 
 class BaseExtension(ABC):
     """Abstract Base Class for Extensions"""
+    @abstractmethod
     def init_extensions(self, config: Dict[str, Any], **kwargs) -> Config:
         # pylint: disable=missing-function-docstring
         pass

--- a/flask_jwt_router/_extensions.py
+++ b/flask_jwt_router/_extensions.py
@@ -2,7 +2,9 @@
      The main configuration class for Flask-JWT-Router
 """
 from abc import ABC
-from typing import Dict, Any
+from typing import Dict, Any, List
+
+from ._entity import _ORMType
 
 
 class Config:
@@ -33,23 +35,26 @@ class Config:
 
 class BaseExtension(ABC):
     """Abstract Base Class for Extensions"""
-    def init_extensions(self, config: Dict[str, Any]) -> Config:
+    def init_extensions(self, config: Dict[str, Any], **kwargs) -> Config:
         # pylint: disable=missing-function-docstring
         pass
 
 
 class Extensions(BaseExtension):
     """Contains the main configuration values"""
-    def init_extensions(self, config: Any) -> Config:
+    entity_models: List[_ORMType]
+
+    def init_extensions(self, config: Any, **kwargs) -> Config:
         """
         :param config:
         :return:
         """
+        entity_models = kwargs.get("entity_models")
         return Config(
             config.get("SECRET_KEY") or "DEFAULT_SECRET_KEY",
             config.get("ENTITY_KEY") or "id",
             config.get("WHITE_LIST_ROUTES") or [],
             config.get("JWT_ROUTER_API_NAME"),
             config.get("IGNORED_ROUTES") or [],
-            config.get("ENTITY_MODELS") or [],
+            entity_models or config.get("ENTITY_MODELS") or [],
         )

--- a/flask_jwt_router/_jwt_router.py
+++ b/flask_jwt_router/_jwt_router.py
@@ -4,9 +4,10 @@
 
 import logging
 from warnings import warn
+from typing import List
 
 from ._extensions import BaseExtension, Extensions, Config
-from ._entity import BaseEntity, Entity
+from ._entity import BaseEntity, Entity, _ORMType
 from ._routing import BaseRouting, Routing
 from ._authentication import BaseAuthStrategy
 
@@ -26,6 +27,9 @@ class FlaskJWTRouter:
 
     #: The Flask application instance.
     app = None
+
+    #: A list of entity models
+    entity_models: List[_ORMType]
 
     #: Token expiry value. eg. 30 = 30 days from creation date.
     exp: int = 30
@@ -50,20 +54,23 @@ class FlaskJWTRouter:
     #: for more information.
     ext: BaseExtension
 
-    def __init__(self, app=None):
+    def __init__(self, app=None, **kwargs):
+        self.entity_models = kwargs.get("entity_models")
         self.ext = Extensions()
+        self.app = app
         if app:
-            self.init_app(app)
+            self.init_app(app, entity_models=self.entity_models)
 
-    def init_app(self, app):
+    def init_app(self, app=None, **kwargs):
         """
         You can use this to set up your config at runtime
         :param app: Flask application instance
         :return:
         """
-        self.app = app
+        self.app = self.app or app
+        entity_models = self.entity_models or kwargs.get("entity_models")
         config = self.get_app_config(app)
-        self.extensions = self.ext.init_extensions(config)
+        self.extensions = self.ext.init_extensions(config, entity_models=entity_models)
         self.entity = Entity(self.extensions)
         self.routing = Routing(self.app, self.extensions, self.entity)
         self.app.before_request(self.routing.before_middleware)

--- a/flask_jwt_router/_jwt_routes.py
+++ b/flask_jwt_router/_jwt_routes.py
@@ -66,15 +66,16 @@
         # Create your entity model (example uses Flask-SqlAlchemy)
 
         class UserModel(db.Model):
+            __tablename__ = "users"
             id = db.Column(db.Integer, primary_key=True)
             name = db.Column(db.String)
 
-        # You can also specify a list of entity model classes
+        JwtRoutes(app, entity_models=[UserModel, TeacherModel, ...etc])
 
-        app.config["ENTITY_MODELS"] = [ UserModel, TeacherModel ]
-
-        # (`id` is used by default)
-        JwtRoutes(app)
+        # Or pass later with `init_app`
+        def create_app(config):
+            ...
+            jwt_routes.init_app(app, entity_models=[UserModel, TeacherModel, ...etc])
 
 
     Authorization & Tokens

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -1,29 +1,32 @@
 from flask_jwt_router._jwt_routes import JwtRoutes
+from flask_jwt_router._extensions import Extensions
+from tests.fixtures.model_fixtures import MockEntityModel
 
 
 class TestExtension:
+    IGNORED_ROUTES = [
+        ("GET", "/"),
+        ("GET", "/ignore"),
+    ]
+    WHITE_LIST_ROUTES = [
+        ("GET", "/test"),
+    ]
 
-    def test_config(self):
-        IGNORED_ROUTES = [
-            ("GET", "/"),
-            ("GET", "/ignore"),
-        ]
-        WHITE_LIST_ROUTES = [
-            ("GET", "/test"),
-        ]
-        class App:
-            config = {
+    config = {
                 "IGNORED_ROUTES": IGNORED_ROUTES,
                 "WHITE_LIST_ROUTES": WHITE_LIST_ROUTES,
             }
-            def before_request(self, t):
-                pass
-        flask_jwt_router = JwtRoutes(App())
-        assert flask_jwt_router.extensions.ignored_routes == IGNORED_ROUTES
-        assert flask_jwt_router.extensions.whitelist_routes == WHITE_LIST_ROUTES
-        flask_jwt = JwtRoutes()
-        flask_jwt.init_app(App())
-        assert flask_jwt.extensions.ignored_routes == IGNORED_ROUTES
-        assert flask_jwt.extensions.whitelist_routes == WHITE_LIST_ROUTES
 
+    def test_init_extensions(self, MockEntityModel):
+        extensions = Extensions()
+        config = extensions.init_extensions(self.config, entity_models=[MockEntityModel])
+
+        assert config.whitelist_routes == self.WHITE_LIST_ROUTES
+        assert config.ignored_routes == self.IGNORED_ROUTES
+        assert config.entity_models == [MockEntityModel]
+
+        config = {**self.config, "ENTITY_MODELS": [MockEntityModel]}
+        con = extensions.init_extensions(config)
+
+        assert con.entity_models == [MockEntityModel]
 

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -15,6 +15,9 @@ class TestExtension:
     config = {
                 "IGNORED_ROUTES": IGNORED_ROUTES,
                 "WHITE_LIST_ROUTES": WHITE_LIST_ROUTES,
+                "SECRET_KEY": "a sectrect key",
+                "JWT_ROUTER_API_NAME": "api/v1",
+                "ENTITY_KEY": "user_id",
             }
 
     def test_init_extensions(self, MockEntityModel):
@@ -24,6 +27,8 @@ class TestExtension:
         assert config.whitelist_routes == self.WHITE_LIST_ROUTES
         assert config.ignored_routes == self.IGNORED_ROUTES
         assert config.entity_models == [MockEntityModel]
+        assert config.entity_key == "user_id"
+        assert config.api_name == "api/v1"
 
         config = {**self.config, "ENTITY_MODELS": [MockEntityModel]}
         con = extensions.init_extensions(config)

--- a/tests/test_jwt_routes.py
+++ b/tests/test_jwt_routes.py
@@ -9,7 +9,7 @@ class TestJwtRoutes:
 
     app = Flask(__name__)
 
-    def test_init_app(self):
+    def test_init_app(self, MockEntityModel):
         jwt = JwtRoutes(self.app, entity_models=[MockEntityModel])
         assert jwt.extensions.entity_models[0] == MockEntityModel
         assert jwt.app == self.app

--- a/tests/test_jwt_routes.py
+++ b/tests/test_jwt_routes.py
@@ -1,0 +1,36 @@
+from flask import Flask
+
+
+from flask_jwt_router._jwt_routes import JwtRoutes
+from tests.fixtures.model_fixtures import MockEntityModel
+
+
+class TestJwtRoutes:
+
+    app = Flask(__name__)
+
+    def test_init_app(self):
+        jwt = JwtRoutes(self.app, entity_models=[MockEntityModel])
+        assert jwt.extensions.entity_models[0] == MockEntityModel
+        assert jwt.app == self.app
+
+        jwt = JwtRoutes()
+        jwt.init_app(self.app, entity_models=[MockEntityModel])
+        assert jwt.extensions.entity_models[0] == MockEntityModel
+        assert jwt.app == self.app
+
+        jwt = JwtRoutes(self.app)
+        jwt.init_app(entity_models=[MockEntityModel])
+        assert jwt.extensions.entity_models[0] == MockEntityModel
+        assert jwt.app == self.app
+
+        jwt = JwtRoutes(entity_models=[MockEntityModel])
+        jwt.init_app(self.app)
+        assert jwt.extensions.entity_models[0] == MockEntityModel
+        assert jwt.app == self.app
+
+        self.app.config["ENTITY_MODELS"] = [MockEntityModel]
+        jwt = JwtRoutes()
+        jwt.init_app(self.app)
+        assert jwt.extensions.entity_models[0] == MockEntityModel
+        assert jwt.app == self.app


### PR DESCRIPTION
Adds to the public api the model declarations. We will continue to provide the option to declare models on Flask's config. 

@kousikmitra @neilong31  would be grateful for a review, thank you