### PR TITLE
Handle possibly URL breaking characters

### DIFF
--- a/flask_jwt_router/oauth2/google.py
+++ b/flask_jwt_router/oauth2/google.py
@@ -153,7 +153,7 @@ class Google(BaseOAuth):
 
     def update_base_path(self, path: str) -> None:
         # TODO rename this method
-        self._url = path + urlencode(dict(
+        self._url = f"{path}?" + urlencode(dict(
           code=self.code,
           client_id=self.client_id,
           client_secret=self.client_secret,

--- a/flask_jwt_router/oauth2/google.py
+++ b/flask_jwt_router/oauth2/google.py
@@ -89,6 +89,7 @@
 """
 from typing import Dict
 from abc import ABC, abstractmethod
+from urllib.parse import urlencode
 
 from .http_requests import HttpRequests
 from ._base import BaseOAuth, _FlaskRequestType
@@ -152,14 +153,13 @@ class Google(BaseOAuth):
 
     def update_base_path(self, path: str) -> None:
         # TODO rename this method
-        url = f"{path}?"
-        url = f"{url}code={self.code}&"
-        url = f"{url}client_id={self.client_id}&"
-        url = f"{url}client_secret={self.client_secret}&"
-        url = f"{url}redirect_uri={self.redirect_uri}&"
-        url = f"{url}grant_type={self.grant_type}&"
-        url = f"{url}expires_in={self.expires_in}"
-        self._url = url
+        self._url = path + urlencode(dict(
+          code=self.code,
+          client_id=self.client_id,
+          client_secret=self.client_secret,
+          redirect_uri=self.redirect_uri,
+          grant_type=self.grant_type,
+          expires_in=self.expires_in))
 
     def _exchange_auth_access_code(self) -> Dict:
         """


### PR DESCRIPTION
If the used variables for building the URL contain any URL characters such as `&`, `/`, `=`, they would create a possibly broken URL. Safer to assume they do and use the builtin urlencode. Also cleans up building the URL.